### PR TITLE
Fix table naming and view loading

### DIFF
--- a/controllers/Offline_payment.php
+++ b/controllers/Offline_payment.php
@@ -42,7 +42,7 @@ class Offline_payment extends AdminController
             $data['banks'] = $this->offline_payment_model->get_banks();
             $data['title'] = _l('offline_payment');
 
-            $this->load->view('themes/' . active_clients_theme() . '/views/offline_payment_form', $data);
+            $this->load->view(module_views_path(OFFLINE_PAYMENT_MODULE_NAME, 'themes/' . active_clients_theme() . '/offline_payment_form'), $data);
             return;
         }
 
@@ -174,7 +174,7 @@ class Offline_payment extends AdminController
         }
 
         $note = $this->input->post('admin_notes');
-        $updated = $this->db->update('tbl_offline_payments', ['admin_notes' => $note], ['id' => $id]);
+        $updated = $this->db->update('tbloffline_payments', ['admin_notes' => $note], ['id' => $id]);
 
         set_alert($updated ? 'success' : 'danger', $updated ? _l('admin_notes') . ' ' . _l('updated_successfully') : _l('update_failed'));
         redirect(admin_url('offline_payment'), 'refresh');
@@ -224,7 +224,7 @@ class Offline_payment extends AdminController
 
     public function get_payment($id)
     {
-        return $this->db->get_where('tbl_offline_payments', ['id' => $id])->row_array();
+        return $this->db->get_where('tbloffline_payments', ['id' => $id])->row_array();
     }
 
     public function submit()

--- a/controllers/Offline_payment_client.php
+++ b/controllers/Offline_payment_client.php
@@ -33,7 +33,7 @@ class Offline_payment_client extends ClientsController
     $data['banks'] = $this->offline_payment_model->get_banks();
     $data['title'] = _l('offline_payment');
 
-    $this->load->view('themes/' . active_clients_theme() . '/offline_payment_form', $data);
+    $this->load->view(module_views_path(OFFLINE_PAYMENT_MODULE_NAME, 'themes/' . active_clients_theme() . '/offline_payment_form'), $data);
 }
 
     public function submit($invoice_id)

--- a/install.php
+++ b/install.php
@@ -1,8 +1,8 @@
 <?php
 defined('BASEPATH') or exit('No direct script access allowed');
 
-if (!$CI->db->table_exists(db_prefix() . 'tbl_offline_payments')) {
-    $CI->db->query('CREATE TABLE `' . db_prefix() . 'tbl_offline_payments` (
+if (!$CI->db->table_exists(db_prefix() . 'offline_payments')) {
+    $CI->db->query('CREATE TABLE `' . db_prefix() . 'offline_payments` (
         `id` INT NOT NULL AUTO_INCREMENT,
         `clientid` INT NOT NULL,
         `invoiceid` INT NOT NULL,

--- a/models/Offline_payment_model.php
+++ b/models/Offline_payment_model.php
@@ -3,7 +3,7 @@ defined('BASEPATH') or exit('No direct script access allowed');
 
 class Offline_payment_model extends App_Model
 {
-    protected $table = 'tbl_offline_payments';
+    protected $table = 'tbloffline_payments';
 
     public function __construct()
     {

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,7 +1,7 @@
 <?php defined('BASEPATH') or exit('No direct script access allowed');
 
 $CI =& get_instance();
-$CI->db->query('DROP TABLE IF EXISTS ' . db_prefix() . 'tbl_offline_payments');
+$CI->db->query('DROP TABLE IF EXISTS ' . db_prefix() . 'offline_payments');
 $CI->db->query('DROP TABLE IF EXISTS ' . db_prefix() . 'offline_payment_banks');
 
 delete_option('offline_payment_email');

--- a/views/manage.php
+++ b/views/manage.php
@@ -214,7 +214,6 @@
 
 <script>
 $(function(){
-  console.log("DataTable exists:", typeof $.fn.DataTable);
 
   $('#offlinePaymentsTable').DataTable({
     pageLength: 15,


### PR DESCRIPTION
## Summary
- ensure database tables use consistent names
- load module views properly for clients
- remove stray console log

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846326e441883288eef2eb82f1c88e9